### PR TITLE
set apipie controller path

### DIFF
--- a/lib/foreman_vault/engine.rb
+++ b/lib/foreman_vault/engine.rb
@@ -21,6 +21,8 @@ module ForemanVault
       Foreman::Plugin.register :foreman_vault do
         requires_foreman '>= 1.20'
 
+        apipie_documented_controllers ["#{ForemanVault::Engine.root}/app/controllers/api/v2/*.rb"]
+
         # Add permissions
         security_block :foreman_vault do
           permission :view_vault_connections,     { vault_connections: [:index, :show],


### PR DESCRIPTION
This overrides the default in https://github.com/theforeman/foreman/blob/ae96cb70130968bdcc8b7a9a9af7edc7c6e0d9a8/lib/tasks/plugin_apipie.rake#L15 that does not apply for this plugin.