### PR TITLE
[TASK] Add support for issueing PKI Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ $ vault secrets enable kv
 
 To set up a connection between Foreman and Vault first navigate to the "Infrastructure" > "Vault Connections" menu and then hit the button labeled "Create Vault Connection". Now you should see a form. You have to fill in name, url and token (you can receive a token with the `$ vault token create -period=60m` command) and hit the "Submit" button.
 
-You can now use `vault_secret(vault_connection_name, secret_path)` macro in your templates to fetch secrets from Vault (you can write secrets with the `$ vault write kv/my_secret foo=bar` command), e.g.
+You can now utilize two new macros in your templates:
+ - vault_secret(vault_connection_name, secret_path)
+ - vault_issue_certificate(vault_connection_name, pki_role_path, options...)
+
+### vault_secret(vault_connection_name, secret_path)
+To fetch secrets from Vault (you can write secrets with the `$ vault write kv/my_secret foo=bar` command), e.g.
 
 ```
 <%= vault_secret('MyVault', 'kv/my_secret') %>
@@ -33,13 +38,23 @@ As result you should get secret data, e.g.
 {:foo=>"bar"}
 ```
 
+### vault_issue_certificate(vault_connection_name, pki_role_path, options...)
+Issueing certificates is just as easy. Be sure to have a correctly set-up PKI, meaning, configure it so you can generate certificates from within the Vault UI. This means that you'll have had to set-up a CA or Intermediate CA. Once done, you can generate a certificate like this:
+
+
+```
+<%= vault_issue_certificate('MyVault', 'pkiEngine/issue/testRole', common_name: 'test.mydomain.com', ttl: '10s') %>
+```
+
+The common_name and ttl are optional, but there are [more options to configure](https://www.vaultproject.io/api/secret/pki/index.html#generate-certificate)
+
 ## Contributing
 
 Fork and send a Pull Request. Thanks!
 
 ## Copyright
 
-Copyright (c) 2018 dmTECH GmbH, [dmtech.de](https://www.dmtech.de/)
+Copyright (c) 2018-2020 dmTECH GmbH, [dmtech.de](https://www.dmtech.de/)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/lib/foreman_vault/macros.rb
+++ b/app/lib/foreman_vault/macros.rb
@@ -11,6 +11,14 @@ module ForemanVault
       raise VaultError, e.message
     end
 
+    def vault_issue_certificate(vault_connection_name, secret_path, *options)
+      vault = VaultConnection.find_by!(name: vault_connection_name)
+      raise VaultError.new(N_('Invalid token for %s'), vault.name) unless vault.token_valid?
+      vault.issue_certificate(secret_path, *options)
+    rescue ActiveRecord::RecordNotFound => e
+      raise VaultError, e.message
+    end
+
     class VaultError < Foreman::Exception; end
   end
 end

--- a/app/models/vault_connection.rb
+++ b/app/models/vault_connection.rb
@@ -13,7 +13,7 @@ class VaultConnection < ApplicationRecord
 
   scope :with_valid_token, -> { where(vault_error: nil).where('expire_time > ?', Time.zone.now) }
 
-  delegate :fetch_expire_time, :fetch_secret, to: :client
+  delegate :fetch_expire_time, :fetch_secret, :issue_certificate, to: :client
 
   def token_valid?
     vault_error.nil? && expire_time && expire_time > Time.zone.now

--- a/app/services/foreman_vault/vault_client.rb
+++ b/app/services/foreman_vault/vault_client.rb
@@ -21,6 +21,12 @@ module ForemanVault
       response.data
     end
 
+    def issue_certificate(secret_path, *options)
+      response = client.logical.write(secret_path, *options)
+      raise NoDataError.new(N_('Could not issue certificate: %s'), secret_path) unless response
+      response.data
+    end
+
     def renew_token
       client.auth_token.renew_self
     end

--- a/lib/foreman_vault/engine.rb
+++ b/lib/foreman_vault/engine.rb
@@ -45,7 +45,7 @@ module ForemanVault
     config.to_prepare do
       begin
         Foreman::Renderer::Scope::Base.include(ForemanVault::Macros)
-        Foreman::Renderer.configure { |c| c.allowed_generic_helpers += [:vault_secret] }
+        Foreman::Renderer.configure { |c| c.allowed_generic_helpers += [:vault_secret, :vault_issue_certificate] }
       rescue StandardError => e
         Rails.logger.warn "ForemanVault: skipping engine hook (#{e})"
       end

--- a/test/unit/services/foreman_vault/vault_client_test.rb
+++ b/test/unit/services/foreman_vault/vault_client_test.rb
@@ -36,4 +36,27 @@ class VaultClientTest < ActiveSupport::TestCase
       assert_equal @data, @subject.fetch_secret(@secret_path)
     end
   end
+
+  describe '#fetch_certificate' do
+    setup do
+      @pki_path = '/pkiEngine/issue/testRole'
+      @data = {
+        certificate: 'CERTIFICATE_DATA',
+        expiration: 1_582_116_230,
+        issuing_ca: 'CA_CERTIFICATE_DATA',
+        private_key: 'PRIVATE_KEY_DATA',
+        private_key_type: 'rsa',
+        serial_number: '7e:2d:c8:dd:df:da:fe:1f:39:da:39:23:4f:74:c8:1f:1d:4a:db:a7'
+      }
+
+      response = OpenStruct.new(data: @data)
+      logical = mock.tap { |object| object.expects(:write).once.with(@pki_path).returns(response) }
+
+      @client.expects(:logical).once.returns(logical)
+    end
+
+    test 'should return new certificate' do
+      assert_equal @data, @subject.issue_certificate(@pki_path)
+    end
+  end
 end


### PR DESCRIPTION
I've added the ability to issue certificates when using a PKI secrets engine.
I've purposely kept the options undefined, as the PKI is a very versatile engine. The only thing that might bother me, is the path, being "<pki_engine_name>/issue/<pki_role>" is to be used to issue a request